### PR TITLE
Config and API Annotations

### DIFF
--- a/src/main/java/devs2blu/hackweek/eventmanager/config/RestConfiguration.java
+++ b/src/main/java/devs2blu/hackweek/eventmanager/config/RestConfiguration.java
@@ -1,0 +1,39 @@
+package devs2blu.hackweek.eventmanager.config;
+
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.metamodel.Type;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.rest.core.config.RepositoryRestConfiguration;
+import org.springframework.data.rest.webmvc.config.RepositoryRestConfigurer;
+import org.springframework.web.servlet.config.annotation.CorsRegistry;
+
+/**
+ * Configuration class for exposing identifiers (IDs) of persisted data entities in a Spring Data REST application.
+ *
+ * This class implements the RepositoryRestConfigurer interface to configure the behavior of Spring Data REST.
+ * It specifically exposes IDs for entities to enable their identification in API responses.
+ *
+ * The main purpose of this configuration is to ensure that the unique identifiers (IDs) of data entities are
+ * included in the responses of Spring Data REST endpoints, allowing clients to easily reference and work with
+ * specific data records.
+ *
+ * This configuration class relies on an EntityManager to access entity metamodel information and determine which
+ * entities' IDs should be exposed.
+ *
+ * @see RepositoryRestConfigurer
+ */
+@Configuration
+public class RestConfiguration implements RepositoryRestConfigurer {
+
+    @Autowired
+    private EntityManager entityManager;
+
+    @Override
+    public void configureRepositoryRestConfiguration(
+            RepositoryRestConfiguration config, CorsRegistry cors) {
+        Class[] classes = entityManager.getMetamodel()
+                .getEntities().stream().map(Type::getJavaType).toArray(Class[]::new);
+        config.exposeIdsFor(classes);
+    }
+}

--- a/src/main/java/devs2blu/hackweek/eventmanager/controllers/ActivityController.java
+++ b/src/main/java/devs2blu/hackweek/eventmanager/controllers/ActivityController.java
@@ -1,17 +1,14 @@
 package devs2blu.hackweek.eventmanager.controllers;
 
-import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
-
 import devs2blu.hackweek.eventmanager.dtos.activity.ActivityRequest;
 import devs2blu.hackweek.eventmanager.dtos.activity.ActivityResponse;
 import devs2blu.hackweek.eventmanager.services.ActivityService;
+import org.springframework.data.rest.webmvc.BasePathAwareController;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 
-@RestController
-@RequestMapping("/activities")
+@BasePathAwareController
 public class ActivityController {
 
     private ActivityService activityService;

--- a/src/main/java/devs2blu/hackweek/eventmanager/controllers/EventController.java
+++ b/src/main/java/devs2blu/hackweek/eventmanager/controllers/EventController.java
@@ -1,21 +1,15 @@
 package devs2blu.hackweek.eventmanager.controllers;
 
-import org.springframework.web.bind.annotation.DeleteMapping;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
-
 import devs2blu.hackweek.eventmanager.dtos.event.EventRequest;
 import devs2blu.hackweek.eventmanager.dtos.event.EventResponse;
 import devs2blu.hackweek.eventmanager.services.EventService;
 import io.swagger.v3.oas.annotations.parameters.RequestBody;
+import org.springframework.data.rest.webmvc.BasePathAwareController;
+import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
 
-@RestController
-@RequestMapping("/events")
+@BasePathAwareController
 public class EventController {
 
     private EventService eventService;

--- a/src/main/java/devs2blu/hackweek/eventmanager/dtos/activity/ActivityRequest.java
+++ b/src/main/java/devs2blu/hackweek/eventmanager/dtos/activity/ActivityRequest.java
@@ -1,8 +1,9 @@
 package devs2blu.hackweek.eventmanager.dtos.activity;
-import java.time.LocalDateTime;
 
 import lombok.Builder;
 import lombok.Getter;
+
+import java.time.LocalDateTime;
 
 @Getter @Builder
 public class ActivityRequest {

--- a/src/main/java/devs2blu/hackweek/eventmanager/dtos/activity/ActivityResponse.java
+++ b/src/main/java/devs2blu/hackweek/eventmanager/dtos/activity/ActivityResponse.java
@@ -1,9 +1,9 @@
 package devs2blu.hackweek.eventmanager.dtos.activity;
 
-import java.time.LocalDateTime;
-
 import lombok.Builder;
 import lombok.Getter;
+
+import java.time.LocalDateTime;
 
 @Getter @Builder
 public class ActivityResponse {

--- a/src/main/java/devs2blu/hackweek/eventmanager/dtos/event/EventRequest.java
+++ b/src/main/java/devs2blu/hackweek/eventmanager/dtos/event/EventRequest.java
@@ -1,8 +1,9 @@
 package devs2blu.hackweek.eventmanager.dtos.event;
-import java.time.LocalDateTime;
 
 import lombok.Builder;
 import lombok.Getter;
+
+import java.time.LocalDateTime;
 
 @Getter @Builder
 public class EventRequest {

--- a/src/main/java/devs2blu/hackweek/eventmanager/dtos/event/EventResponse.java
+++ b/src/main/java/devs2blu/hackweek/eventmanager/dtos/event/EventResponse.java
@@ -1,8 +1,9 @@
 package devs2blu.hackweek.eventmanager.dtos.event;
 
-import java.time.LocalDateTime;
 import lombok.Builder;
 import lombok.Getter;
+
+import java.time.LocalDateTime;
 
 
 @Getter @Builder

--- a/src/main/java/devs2blu/hackweek/eventmanager/entities/Activity.java
+++ b/src/main/java/devs2blu/hackweek/eventmanager/entities/Activity.java
@@ -1,11 +1,7 @@
 package devs2blu.hackweek.eventmanager.entities;
 
 import jakarta.persistence.*;
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
-import lombok.Setter;
+import lombok.*;
 
 import java.sql.Timestamp;
 

--- a/src/main/java/devs2blu/hackweek/eventmanager/entities/Event.java
+++ b/src/main/java/devs2blu/hackweek/eventmanager/entities/Event.java
@@ -1,11 +1,7 @@
 package devs2blu.hackweek.eventmanager.entities;
 
 import jakarta.persistence.*;
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
-import lombok.Setter;
+import lombok.*;
 
 import java.sql.Timestamp;
 import java.util.List;

--- a/src/main/java/devs2blu/hackweek/eventmanager/entities/User.java
+++ b/src/main/java/devs2blu/hackweek/eventmanager/entities/User.java
@@ -7,8 +7,6 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
 
-import java.sql.Timestamp;
-import java.time.LocalDate;
 import java.util.Set;
 
 @Entity

--- a/src/main/java/devs2blu/hackweek/eventmanager/repositories/ActivityRepository.java
+++ b/src/main/java/devs2blu/hackweek/eventmanager/repositories/ActivityRepository.java
@@ -1,9 +1,9 @@
 package devs2blu.hackweek.eventmanager.repositories;
 
 import devs2blu.hackweek.eventmanager.entities.Activity;
-import java.util.List;
-
 import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
 
 public interface ActivityRepository extends JpaRepository<Activity, Long> {
     List<Activity> findAllByEventId(Long id);

--- a/src/main/java/devs2blu/hackweek/eventmanager/services/ActivityService.java
+++ b/src/main/java/devs2blu/hackweek/eventmanager/services/ActivityService.java
@@ -1,8 +1,4 @@
 package devs2blu.hackweek.eventmanager.services;
-import java.time.LocalDateTime;
-import java.sql.Timestamp;
-
-import org.springframework.stereotype.Service;
 
 import devs2blu.hackweek.eventmanager.dtos.activity.ActivityRequest;
 import devs2blu.hackweek.eventmanager.dtos.activity.ActivityResponse;
@@ -12,6 +8,9 @@ import devs2blu.hackweek.eventmanager.entities.Speaker;
 import devs2blu.hackweek.eventmanager.repositories.ActivityRepository;
 import devs2blu.hackweek.eventmanager.repositories.EventRepository;
 import devs2blu.hackweek.eventmanager.repositories.SpeakerRepository;
+import org.springframework.stereotype.Service;
+
+import java.sql.Timestamp;
 
 @Service
 public class ActivityService {

--- a/src/main/java/devs2blu/hackweek/eventmanager/services/EventService.java
+++ b/src/main/java/devs2blu/hackweek/eventmanager/services/EventService.java
@@ -1,9 +1,5 @@
 package devs2blu.hackweek.eventmanager.services;
 
-import java.util.List;
-
-import org.springframework.stereotype.Service;
-
 import devs2blu.hackweek.eventmanager.dtos.event.EventRequest;
 import devs2blu.hackweek.eventmanager.dtos.event.EventResponse;
 import devs2blu.hackweek.eventmanager.entities.Activity;
@@ -11,6 +7,9 @@ import devs2blu.hackweek.eventmanager.entities.Event;
 import devs2blu.hackweek.eventmanager.repositories.ActivityRepository;
 import devs2blu.hackweek.eventmanager.repositories.EventRepository;
 import devs2blu.hackweek.eventmanager.services.builders.Builders;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
 
 @Service
 public class EventService {

--- a/src/main/java/devs2blu/hackweek/eventmanager/services/builders/Builders.java
+++ b/src/main/java/devs2blu/hackweek/eventmanager/services/builders/Builders.java
@@ -3,6 +3,7 @@ package devs2blu.hackweek.eventmanager.services.builders;
 import devs2blu.hackweek.eventmanager.dtos.event.EventRequest;
 import devs2blu.hackweek.eventmanager.dtos.event.EventResponse;
 import devs2blu.hackweek.eventmanager.entities.Event;
+
 import java.sql.Timestamp;
 
 public class Builders {


### PR DESCRIPTION
Adicionei uma configuração para injetar o Id da própria entidade nas respostas pro front e Mudei as anotações de `@RestController ` para `@BasePathAwareController`, de acordo com a sugestão da recomendação do Spring Data Rest

[Overriding Spring Data REST Response Handlers](https://docs.spring.io/spring-data/rest/docs/current/reference/html/#customizing-sdr.overriding-sdr-response-handlers)

> Sometimes, you may want to write a custom handler for a specific resource. To take advantage of Spring Data REST’s settings, message converters, exception handling, and more, use the `@RepositoryRestController` annotation instead of a standard Spring MVC `@Controller` or `@RestController.` Controllers annotated with `@RepositoryRestController` are served from the API base path defined in `RepositoryRestConfiguration.setBasePath`, which is used by all other `RESTful` endpoints (for example, /api).

Como nossos endpoints são gerados a partir do Repository, com essas anotações conseguimos nos comunicar com elas e fazer alterações customizadas a rotas específicas.